### PR TITLE
feat: add local storage for warmup results and study session duration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'routes/app_routes.dart';
 // === Services & Controllers ===
 import 'services/ble_service.dart'; // stub sekarang, real nanti tinggal uncomment
 import 'services/audio_service.dart'; // stub sekarang, real nanti tinggal uncomment
+import 'services/local_storage_service.dart';
 import 'controllers/bluetooth_controller.dart';
 import 'controllers/music_controller.dart';
 import 'controllers/session_controller.dart';
@@ -43,6 +44,7 @@ class _CoreBinding extends Bindings {
     // Services (permanent agar tetap hidup sepanjang app)
     Get.put<BleService>(BleService(), permanent: true);
     Get.put<AudioService>(AudioService(), permanent: true);
+    Get.put<LocalStorageService>(LocalStorageService(), permanent: true); // ⬅️ NEW
 
     // Controllers yang bergantung pada services di atas
     Get.put<BluetoothController>(
@@ -62,3 +64,4 @@ class _CoreBinding extends Bindings {
     );
   }
 }
+

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -12,7 +12,7 @@ import 'routes_name.dart';
 import '../view/onboarding_flow.dart';
 
 class AppRoutes {
-  static const initRoute = RoutesName.motivation;
+  static const initRoute = RoutesName.onboardingFlow;
 
   static final routes = [
     GetPage(

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -1,15 +1,28 @@
 // lib/services/local_storage_service.dart
-
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// Single place to persist lightweight user & session data.
+/// Uses SharedPreferences under the hood.
 class LocalStorageService {
-  // Keys for storing data. Using constants is a good practice to avoid typos.
+  // ===== Onboarding keys =====
   static const String _nameKey = 'userName';
   static const String _classKey = 'userClass';
   static const String _universityKey = 'userUniversity';
   static const String _majorKey = 'userMajor';
 
-  // Method to save all user onboarding data
+  // ===== Session keys =====
+  static const String _selectedModeKey = 'session_selected_mode';       // String (SessionMode.name)
+  static const String _warmupScoreKey = 'session_warmup_score';         // int
+  static const String _warmupQuestionsKey = 'session_warmup_questions'; // int
+  static const String _warmupDoneKey = 'session_warmup_done';           // bool
+
+  static const String _studyStartedAtKey = 'session_study_started_at';  // int (ms since epoch)
+  static const String _studyDurationSecKey = 'session_study_duration';  // int (seconds)
+  static const String _studyDoneKey = 'session_study_done';             // bool
+
+  // ===========================
+  // Onboarding
+  // ===========================
   Future<void> saveUserData({
     required String name,
     required String userClass,
@@ -23,7 +36,6 @@ class LocalStorageService {
     await prefs.setString(_majorKey, major);
   }
 
-  // Method to retrieve all user data
   Future<Map<String, String>> getUserData() async {
     final prefs = await SharedPreferences.getInstance();
     return {
@@ -32,5 +44,87 @@ class LocalStorageService {
       'university': prefs.getString(_universityKey) ?? '',
       'major': prefs.getString(_majorKey) ?? '',
     };
+  }
+
+  // ===========================
+  // Session: Mode
+  // ===========================
+  /// Save the selected mode as a string (use `SessionMode.name` when calling).
+  Future<void> setSelectedModeString(String modeName) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_selectedModeKey, modeName);
+  }
+
+  /// Read the selected mode as a string. Convert to enum at the call site if needed.
+  Future<String?> getSelectedModeString() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_selectedModeKey);
+  }
+
+  // ===========================
+  // Session: Warmup
+  // ===========================
+  Future<void> setWarmupResult({
+    required int score,
+    required int totalQuestions,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_warmupScoreKey, score);
+    await prefs.setInt(_warmupQuestionsKey, totalQuestions);
+    await prefs.setBool(_warmupDoneKey, true);
+  }
+
+  /// Returns: {'score': int, 'total': int, 'done': bool}
+  Future<Map<String, Object>> getWarmupSummary() async {
+    final prefs = await SharedPreferences.getInstance();
+    return {
+      'score': prefs.getInt(_warmupScoreKey) ?? 0,
+      'total': prefs.getInt(_warmupQuestionsKey) ?? 0,
+      'done': prefs.getBool(_warmupDoneKey) ?? false,
+    };
+  }
+
+  // ===========================
+  // Session: Study
+  // ===========================
+  /// Mark study as started right now (stores the start timestamp).
+  Future<void> markStudyStartedNow() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_studyStartedAtKey, DateTime.now().millisecondsSinceEpoch);
+    await prefs.setBool(_studyDoneKey, false);
+  }
+
+  /// When study completes, persist the duration in seconds and set done=true.
+  Future<void> markStudyCompleted({required int durationSeconds}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_studyDurationSecKey, durationSeconds);
+    await prefs.setBool(_studyDoneKey, true);
+  }
+
+  /// Returns: {'startedAt': DateTime? , 'durationSec': int, 'done': bool}
+  Future<Map<String, Object?>> getStudySummary() async {
+    final prefs = await SharedPreferences.getInstance();
+    final startedMs = prefs.getInt(_studyStartedAtKey);
+    return {
+      'startedAt': startedMs == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(startedMs),
+      'durationSec': prefs.getInt(_studyDurationSecKey) ?? 0,
+      'done': prefs.getBool(_studyDoneKey) ?? false,
+    };
+  }
+
+  // ===========================
+  // Session: Reset (optional)
+  // ===========================
+  Future<void> clearSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_selectedModeKey);
+    await prefs.remove(_warmupScoreKey);
+    await prefs.remove(_warmupQuestionsKey);
+    await prefs.remove(_warmupDoneKey);
+    await prefs.remove(_studyStartedAtKey);
+    await prefs.remove(_studyDurationSecKey);
+    await prefs.remove(_studyDoneKey);
   }
 }

--- a/lib/view/homepage.dart
+++ b/lib/view/homepage.dart
@@ -10,6 +10,7 @@ import '../controllers/session_controller.dart';
 import '../models/mode.dart';
 import '../models/session_state.dart'; // <-- pakai enum SessionPhase
 import '../routes/routes_name.dart';
+import '../services/local_storage_service.dart';
 import '../utils.dart';
 
 // Ganti import ini dengan file real kamu
@@ -101,15 +102,19 @@ class _HomeTabState extends State<HomeTab> with WidgetsBindingObserver {
     final mode = await showModePicker(context);
     if (mode == null) return;
 
-    // store the selection in your session controller (same as before)
+    // keep your existing controller logic
     await widget.session.selectMode(mode);
+
+    // persist to local storage for restore
+    final store = Get.find<LocalStorageService>();
+    await store.setSelectedModeString(mode.name);
 
     if (!mounted) return;
 
-    // jump straight to Motivation with the selected mode
+    // navigate to Motivation
     Get.toNamed(
       RoutesName.motivation,
-      arguments: {'mode': mode},
+      arguments: {'isStarting': true},
     );
   }
 
@@ -228,21 +233,6 @@ class _HomeTabState extends State<HomeTab> with WidgetsBindingObserver {
                       ],
                     ),
                   ),
-                );
-              }),
-
-              // ---------- Mode siap (kecil & rapi) ----------
-              const SizedBox(height: 12),
-              Obx(() {
-                final isPrepared =
-                    widget.session.phase.value == SessionPhase.prepared;
-                final selectedMode = widget.session.info?.mode;
-                if (!isPrepared || selectedMode == null) {
-                  return const SizedBox.shrink();
-                }
-                return Text(
-                  'Mode siap: ${selectedMode.name}',
-                  style: bodyText12.copyWith(color: neutral600),
                 );
               }),
             ],

--- a/lib/view/study_session_result_page.dart
+++ b/lib/view/study_session_result_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../routes/routes_name.dart';
+import '../services/local_storage_service.dart';
+import '../models/mode.dart';
 import '../utils.dart';
 
 class StudySessionResultPage extends StatelessWidget {
@@ -8,50 +10,109 @@ class StudySessionResultPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Spacer(),
-              Text(
-                "Sesi Fokus Selesai!",
-                style: mobileH2.copyWith(color: neutral800),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 40),
-              Image.asset(
-                "assets/images/star-spark-confetti.png",
-                height: 400,
-              ),
-              const SizedBox(height: 40),
-              Text(
-                "Kerja bagus!\nkamu mendapatkan 10 poin",
-                style: bodyText18.copyWith(color: neutral700),
-                textAlign: TextAlign.center,
-              ),
-              const Spacer(),
-              SizedBox(
-                width: double.infinity,
-                height: 56,
-                child: ElevatedButton(
-                  onPressed: () => Get.offAllNamed(RoutesName.homepage),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: brand600,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(28)),
+    final store = Get.find<LocalStorageService>();
+
+    return FutureBuilder(
+      future: Future.wait([
+        store.getWarmupSummary(),   // {'score': int, 'total': int, 'done': bool}
+        store.getStudySummary(),    // {'startedAt': DateTime?, 'durationSec': int, 'done': bool}
+        store.getSelectedModeString(), // String? (SessionMode.name) — optional
+      ]),
+      builder: (context, snap) {
+        if (!snap.hasData) {
+          return const Scaffold(
+            backgroundColor: Colors.white,
+            body: SafeArea(child: Center(child: CircularProgressIndicator())),
+          );
+        }
+
+        final warmup = snap.data![0] as Map<String, Object>;
+        final study  = snap.data![1] as Map<String, Object?>;
+        final modeStr = snap.data![2] as String?;
+        SessionMode? mode;
+        if (modeStr != null) {
+          try { mode = SessionMode.values.firstWhere((e) => e.name == modeStr); } catch (_) {}
+        }
+
+        final score = (warmup['score'] as int?) ?? 0;
+        final total = (warmup['total'] as int?) ?? 0;
+        final durationSec = (study['durationSec'] as int?) ?? 0;
+
+        String durationText;
+        final mins = durationSec ~/ 60;
+        final secs = durationSec % 60;
+        if (mins > 0) {
+          durationText = '${mins}m ${secs}s';
+        } else {
+          durationText = '${secs}s';
+        }
+
+        return Scaffold(
+          backgroundColor: Colors.white,
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Spacer(),
+                  Text(
+                    "Sesi Fokus Selesai!",
+                    style: mobileH2.copyWith(color: neutral800),
+                    textAlign: TextAlign.center,
                   ),
-                  child: Text("Home", style: buttonText),
-                ),
+                  const SizedBox(height: 40),
+                  Image.asset(
+                    "assets/images/star-spark-confetti.png",
+                    height: 400,
+                  ),
+                  const SizedBox(height: 40),
+
+                  // 🔹 Dynamic summary
+                  Column(
+                    children: [
+                      if (mode != null)
+                        Text(
+                          "Mode: ${mode == SessionMode.chill ? 'CHILL' : 'LEARN'}",
+                          style: bodyText16.copyWith(color: neutral700),
+                          textAlign: TextAlign.center,
+                        ),
+                      const SizedBox(height: 8),
+                      Text(
+                        "Warmup: $score / $total poin",
+                        style: bodyText18.copyWith(color: neutral700),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        "Durasi belajar: $durationText",
+                        style: bodyText18.copyWith(color: neutral700),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+
+                  const Spacer(),
+                  SizedBox(
+                    width: double.infinity,
+                    height: 56,
+                    child: ElevatedButton(
+                      onPressed: () => Get.offAllNamed(RoutesName.homepage),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: brand600,
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(28)),
+                      ),
+                      child: Text("Home", style: buttonText),
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/view/warmup_page.dart
+++ b/lib/view/warmup_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_tts/flutter_tts.dart'; // <-- 1. Import the package
 import 'package:get/get.dart';
 import '../routes/routes_name.dart';
+import '../services/local_storage_service.dart';
 import '../utils.dart';
 
 class WarmUpPage extends StatefulWidget {
@@ -186,7 +187,7 @@ class _WarmUpPageState extends State<WarmUpPage> {
     });
   }
 
-  void _nextQuestionOrFinish() {
+  Future<void> _nextQuestionOrFinish() async {
     _questionTimer?.cancel();
 
     // If this was the last question, do NOT increment _qIndex.
@@ -194,6 +195,11 @@ class _WarmUpPageState extends State<WarmUpPage> {
     final isLast = _qIndex >= lastIndex;
 
     if (isLast) {
+      // ⬇️ Persist warmup summary and stamp study start time
+      final store = Get.find<LocalStorageService>();
+      await store.setWarmupResult(score: _totalScore, totalQuestions: _questions.length);
+      await store.markStudyStartedNow();
+
       // Navigate after the current frame to avoid build re-entrancy.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;


### PR DESCRIPTION
- save selected mode to SharedPreferences
- store warmup score and total questions on completion
- stamp study start time; compute and persist study duration on end
- read persisted values on StudySessionResultPage